### PR TITLE
Give proper error message when no running nodes found.

### DIFF
--- a/src/nodes/list.js
+++ b/src/nodes/list.js
@@ -42,6 +42,7 @@ async function listNodes (clientId, accessToken, flags) {
     }
 
     if (!body.length) {
+      const user = `${config.get('user')}`
       return consola.success(`No nodes were found for user ${user}`)
     }
 


### PR DESCRIPTION
When there are no running nodes, user is not defined so instead of the
correct error, we get a ReferenceError.  This commit fixes that.