### PR TITLE
Switch to IP address rather than DNS name

### DIFF
--- a/src/nodes/info.js
+++ b/src/nodes/info.js
@@ -54,7 +54,7 @@ async function infoNode (clientId, accessToken, flags) {
     * Vendor:
     \t- LaunchTime:\t${vendor.LaunchTime}
     \t- Architecture:\t${vendor.Architecture}
-    \t- PublicDnsName:\t${vendor.PublicDnsName || '-'}
+    \t- PublicIpAddress:\t${vendor.PublicIpAddress || '-'}
     `)
   })
 }

--- a/src/nodes/list.js
+++ b/src/nodes/list.js
@@ -33,7 +33,7 @@ async function listNodes (clientId, accessToken, flags) {
     body = body.map(function (n) {
       delete n.user
       delete n.instance
-      n.PublicDnsName = n.vendor.PublicDnsName
+      n.PublicIpAddress = n.vendor.PublicIpAddress
       delete n.vendor
       return n
     })


### PR DESCRIPTION
The IP addresses are actually shorter and friendlier
than the PublicDns names assigned so use them instead.