### PR TITLE
Fix returned results from verify command

### DIFF
--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -48,7 +48,7 @@ class VerifyCommand extends Command {
         return consola.error('Invalid verification token')
       }
 
-      consola.success(`The account with id ${body.id} has been validated.`)
+      consola.success(`The account with id ${data.body.id} has been validated.`)
       consola.info(`You can now start a new session running the command: bcl login -u ${user}`)
     })
   }


### PR DESCRIPTION
Without this fix I get:
```
jcv@triforce cloud-cli $ node bin/run verify                                                          
ℹ Verifyng your BloqCloud account.                                                                                                                                                                      17:03:45
? Enter your account id  user-126047c3-d637-4eb5-9bca-f1f8dcbcb8e8                      
? Enter your verification token 8423e7af-3f1d-46ae-bbf7-476c9c13ef0e
http://localhost:4000/users/ user-126047c3-d637-4eb5-9bca-f1f8dcbcb8e8/token/8423e7af-3f1d-46ae-bbf7-476c9c13ef0e
/home/jcv/code/bloq/cloud/cloud-cli/src/commands/verify.js:51                                    
      consola.success(`The account with id ${body.id} has been validated.`)
                                             ^                                            
  
ReferenceError: body is not defined                                            
    at Request._callback (/home/jcv/code/bloq/cloud/cloud-cli/src/commands/verify.js:51:46)
    at Request.self.callback (/home/jcv/code/bloq/cloud/cloud-cli/node_modules/request/request.js:185:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)                                                         
    at Request.<anonymous> (/home/jcv/code/bloq/cloud/cloud-cli/node_modules/request/request.js:1161:10)
    at emitOne (events.js:116:13)                      
    at Request.emit (events.js:211:7)                                                       
    at IncomingMessage.<anonymous> (/home/jcv/code/bloq/cloud/cloud-cli/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:313:30)                      
    at emitNone (events.js:111:20)
```