### PR TITLE
Support insight envs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,9 +112,9 @@
       }
     },
     "@bloq/cloud-sdk": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@bloq/cloud-sdk/-/cloud-sdk-0.1.3.tgz",
-      "integrity": "sha512-/+M9fTH6OW49g5IOtULleqGQdo795gUG2Y3728+sg/Uzr9QmHf8lUeR3SgPn0GR4C0XxrXIbPcgDV+4/K3hEbg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bloq/cloud-sdk/-/cloud-sdk-1.0.0.tgz",
+      "integrity": "sha512-syHSUQBKrcc7+xl4tNgrBH8rRGZXRgHK4B+rPl8wf/ndhczHq060JPJ+RjU5/R+A0OPtAKI96B2I4ZGrp3gylw==",
       "requires": {
         "axios": "^0.18.0",
         "socket.io-client": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/bloqpriv/cloud-cli/issues",
   "dependencies": {
-    "@bloq/cloud-sdk": "0.1.3",
+    "@bloq/cloud-sdk": "1.0.0",
     "@oclif/command": "1.5.13",
     "@oclif/config": "1.12.12",
     "@oclif/plugin-help": "2.1.6",


### PR DESCRIPTION
Support bloqclouddev insight enviroment. To use this, run `bcl conf env stage`.
We will need to publish a new NPM version.