### PR TITLE
Fix BCH status URL and chars

### DIFF
--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -61,26 +61,26 @@ class StatusCommand extends Command {
         const status = [
           {
             service: 'Accounts',
-            isUp: isAccountsUp ? '✔' : '❌',
+            status: isAccountsUp ? 'OK' : 'DOWN',
             url: services[env].accounts.url
           },
 
           {
             service: 'Nodes',
-            isUp: isNodesUp ? '✔' : '❌',
+            status: isNodesUp ? 'OK' : 'DOWN',
             url: services[env].nodes.url
           },
 
           {
             service: 'Connect BTC',
-            isUp: isConnectBtcUp ? '✔' : '❌',
+            status: isConnectBtcUp ? 'OK' : 'DOWN',
             url: services[env].connect.btc.url
           },
 
           {
             service: 'Connect BCH',
-            isUp: isConnectBchUp ? '✔' : '❌',
-            url: services[env].connect.btc.url
+            status: isConnectBchUp ? 'OK' : 'DOWN',
+            url: services[env].connect.bch.url
           }
         ]
 


### PR DESCRIPTION
Fix #134 by using the correct URL for BCH.

Also, replace the unicode chars with standard text to maximize compatibility. 