### PR TITLE
Allow all users to remove their own clusters

### DIFF
--- a/src/clusters/remove.js
+++ b/src/clusters/remove.js
@@ -4,7 +4,6 @@ const ora = require('ora')
 const consola = require('consola')
 const request = require('request')
 const inquirer = require('inquirer')
-const jwtDecode = require('jwt-decode')
 
 const config = require('../config')
 
@@ -18,11 +17,6 @@ const config = require('../config')
  */
 async function removeCluster ({ accessToken, clusterId }) {
   consola.info('Removing cluster')
-
-  const payload = jwtDecode(accessToken)
-  if (!payload.aud.includes('manager')) {
-    return consola.error('Only admin users can manage clusters with the CLI')
-  }
 
   if (!clusterId) {
     const prompt = await inquirer.prompt([


### PR DESCRIPTION
This PR removes the check that allowed only admins to remove clusters. The endpoint in the Nodes service checks the cluster belongs to the user, so no security issues.

Related to: https://github.com/bloqpriv/bloq-services-monorepo/issues/1376