### PR TITLE
Display the cluster alias in the list

### DIFF
--- a/src/clusters/list.js
+++ b/src/clusters/list.js
@@ -39,20 +39,22 @@ async function listClusters ({ accessToken, all }) {
 
     let body = JSON.parse(data.body)
     body = body.map(function ({
-      id,
+      alias,
       chain,
-      state,
-      network,
-      ip,
       createdAt,
-      serviceData,
+      id,
+      name,
+      network,
+      serviceData = {},
+      state,
       stoppedAt
     }) {
       const cluster = {
         id,
         chain,
         network,
-        ip,
+        name: alias || name,
+        subdomain: name,
         state,
         createdAt,
         version: serviceData.software,


### PR DESCRIPTION
Much nicer cluster list now!

```console
$ bcl clusters list
ℹ Retrieving clusters.                                                                                                    17:40:25
✔ Got 8 clusters:                                                                                                         17:40:26

id                                            chain  network  name                         subdomain             state    createdAt                 version                   performance
--------------------------------------------  -----  -------  ---------------------------  --------------------  -------  ------------------------  ------------------------  -----------
cluster-2f42c101-fae5-4ea0-b583-66137d69de9b  eth    goerli   eth-connect-staging-goerli   render-cute-thunder   started  2020-07-20T21:24:43.984Z  openethereum-archive-3.0  standard   
...
cluster-5957235b-1ce6-4ca2-a360-e5ce2e3cb843  eth    rinkeby  eth-connect-staging-rinkeby  race-chunk-hawk       started  2020-06-30T13:59:43.600Z  openethereum-3.0          standard   
```