### PR TITLE
Improve output when creating a node or cluster

### DIFF
--- a/src/clusters/create.js
+++ b/src/clusters/create.js
@@ -85,16 +85,13 @@ async function createCluster (params) {
       return consola.error(`Error initializing the new cluster: ${body.code}`)
     }
 
-    process.stdout.write('\n')
-
-    coppyToClipboard(body.id, 'Cluster id')
-
     const creds =
       body.auth.type === 'jwt'
         ? '* Auth:\t\tJWT'
         : `* User:\t\t${body.auth.user}
     * Password:\t\t${body.auth.pass}`
 
+    process.stdout.write('\n')
     consola.success(`Initialized new cluster from service ${serviceId}
     * ID:\t\t${body.id}
     * Name:\t\t${body.name}
@@ -107,6 +104,9 @@ async function createCluster (params) {
     * Region:\t\t${body.region}
     * State:\t\t${body.state}
     ${creds}`)
+
+    process.stdout.write('\n')
+    coppyToClipboard(body.id, 'Cluster id')
   })
 }
 

--- a/src/nodes/create.js
+++ b/src/nodes/create.js
@@ -59,9 +59,6 @@ async function createNode ({ accessToken, serviceId, authType }) {
     }
 
     const { id, auth, state, chain, network, serviceData, ip } = data.body
-    process.stdout.write('\n')
-
-    coppyToClipboard(id, 'Node id')
 
     const creds =
       auth.type === 'jwt'
@@ -69,6 +66,7 @@ async function createNode ({ accessToken, serviceId, authType }) {
         : `* User:\t\t${auth.user}
     * Password:\t\t${auth.pass}`
 
+    process.stdout.write('\n')
     consola.success(`Initialized new node from service ${serviceId}
     * ID:\t\t${id}
     * Chain:\t\t${chain}
@@ -78,6 +76,9 @@ async function createNode ({ accessToken, serviceId, authType }) {
     * State:\t\t${state}
     * IP:\t\t${ip}
     ${creds}`)
+
+    process.stdout.write('\n')
+    coppyToClipboard(id, 'Node id')
   })
 }
 


### PR DESCRIPTION
Move the "ID copied to clipboard" notice to the end and separated by a new line for increased readability and awareness.