### PR TITLE
Fix auth info when creating no-auth cluster

### DIFF
--- a/src/clusters/create.js
+++ b/src/clusters/create.js
@@ -86,10 +86,15 @@ async function createCluster (params) {
     }
 
     const creds =
-      body.auth.type === 'jwt'
-        ? '* Auth:\t\tJWT'
-        : `* User:\t\t${body.auth.user}
+    body.auth.type === 'jwt'
+      ? `
+    * Auth:\t\tJWT`
+      : body.auth.type === 'basic'
+        ? `
+    * User:\t\t${body.auth.user}
     * Password:\t\t${body.auth.pass}`
+        : `
+    * Auth:\t\tnone`
 
     process.stdout.write('\n')
     consola.success(`Initialized new cluster from service ${serviceId}
@@ -102,8 +107,7 @@ async function createCluster (params) {
     * Domain:\t\t${body.domain}
     * Capacity:\t\t${body.onDemandCapacity}:${body.capacity}
     * Region:\t\t${body.region}
-    * State:\t\t${body.state}
-    ${creds}`)
+    * State:\t\t${body.state}${creds}`)
 
     process.stdout.write('\n')
     coppyToClipboard(body.id, 'Cluster id')

--- a/src/clusters/info.js
+++ b/src/clusters/info.js
@@ -71,7 +71,6 @@ async function infoCluster ({ accessToken, clusterId }) {
     * Auth:\t\tnone`
 
     process.stdout.write('\n')
-
     consola.success(`Retrieved cluster with id ${clusterId}
     * ID:\t\t${body.id}
     * Name:\t\t${body.name}


### PR DESCRIPTION
It was fixed in `bcl clusters info` but not in `create`.