### PR TITLE
Remove incorrect on-demand capacity default

### DIFF
--- a/src/commands/clusters.js
+++ b/src/commands/clusters.js
@@ -51,8 +51,7 @@ ClusterCommand.flags = {
   }),
   onDemandCapacity: flags.integer({
     char: 'o',
-    description: 'on-demand capacity',
-    default: 1
+    description: 'on-demand capacity'
   }),
   all: flags.boolean({
     char: 'a',


### PR DESCRIPTION
<!-- Explain the changes included in this PR and why are relevant or what problem does it solve. -->

While the API was correctly creating clusters with all-on-demand instances when only the total capacity was specified, the CLI was sending an incorrect default of 1, forcing the API to fill in the rest of the capacity with spot instances.

This PR removes the default on-demand capacity in the CLI to prevent creating clusters with spot instances by accident.

### Process checklist

- [x] Manual tests passed.
- [ ] Automated tests added.
- [ ] Documentation updated.

### Metrics

<!-- Add the actual effort spent working in this PR.
Use hours or days as appropriate.
Consider 0.5h as the lower limit. -->

Actual effort: 0.5h
