### PR TITLE
Adds help text for using quotes on password

### DIFF
--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 'use strict'
 const ora = require('ora')
 const request = require('request')
@@ -42,7 +43,11 @@ class LoginCommand extends Command {
 
     if (!password) {
       const prompt = await inquirer.prompt([
-        { name: 'password', message: 'Enter your password', type: 'password' }
+        {
+          name: 'password',
+          message: 'Enter your password (without quotes)',
+          type: 'password'
+        }
       ])
 
       password = prompt.password
@@ -94,8 +99,11 @@ class LoginCommand extends Command {
 LoginCommand.description = 'Login to your Bloq account'
 
 LoginCommand.flags = {
-  user: flags.string({ char: 'u', description: 'email address or account id' }),
-  password: flags.string({ char: 'p', description: 'password' })
+  password: flags.string({
+    char: 'p',
+    description: `'password', surrounded by quotes`
+  }),
+  user: flags.string({ char: 'u', description: 'email address or account id' })
 }
 
 module.exports = LoginCommand


### PR DESCRIPTION
After creating new accounts and update them to complex passwords, there was no much code to add, since the actual one _does_ support hyphens and exclamation marks for passwords, but **only when surrounded** by single quotation marks ( ' ). Example:
```
bcl login -u admin@bloq.com -p my--Pass   <-- failed
bcl login -u admin@bloq.com -p myPass!!!   <-- failed
bcl login -u admin@bloq.com -p 'my--Pass'   <-- success
bcl login -u admin@bloq.com -p 'myPass!!!'   <-- success
```
When `-p` is omitted it will be asked later and those passwords will be accepted with no problem.

### Screenshots

Hence, this PR will include a wee text reminder to show to the user where and where not to use quotation marks, and get their passwords accepted:

<img width="621" alt="image" src="https://user-images.githubusercontent.com/6036099/161198389-e9ca281f-be70-44c4-9297-830a72b3c17b.png">


### Process checklist

- [x] Manual tests passed.
- [ ] Automated tests added.
- [ ] Documentation updated.

### Related issue(s)

Closes #191 

### Metrics

Actual effort: 4h
