### PR TITLE
Improves help msg on clientKeys command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ARGUMENTS
   OPERATION  (create|list|remove) [default: list] Specify the type of client-keys operation to run
 
 OPTIONS
-  -i, --keyId=clientKeyId  client key id, used by `remove` operation only
+  -i, --keyId=keyId  client key id, used by `remove` operation only
 ```
 
 _See code: [src/commands/client-keys.js](https://github.com/bloqpriv/cloud-cli/blob/v3.1.0/src/commands/client-keys.js)_

--- a/src/client-keys/remove.js
+++ b/src/client-keys/remove.js
@@ -1,4 +1,3 @@
-/* eslint-disable consistent-return */
 'use strict'
 
 const config = require('../config')
@@ -23,7 +22,7 @@ async function removeClientKey(user, accessToken, flags) {
       { name: 'keyId', message: 'Enter the client-key id', type: 'text' }
     ])
 
-    keyId = prompt.clientKeyId
+    keyId = prompt.keyId
     if (!keyId) {
       consola.error('Missing client key id')
       return

--- a/src/commands/client-keys.js
+++ b/src/commands/client-keys.js
@@ -1,4 +1,3 @@
-/* eslint-disable consistent-return */
 /* eslint-disable no-shadow */
 'use strict'
 

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -72,28 +72,35 @@ class LoginCommand extends Command {
     return fetch(url, params)
       .then(res => {
         spinner.stop()
-
         if (res.status === 401 || res.status === 403) {
-          consola.error('The username or password you entered is incorrect')
-          return
+          return {
+            ok: false,
+            status: res.status,
+            message: 'The username or password you entered is incorrect'
+          }
         }
 
         if (res.status !== 200) {
-          consola.error(
-            `Error retrieving access token: ${res.statusText || res.status}`
-          )
-          return
+          return {
+            ok: false,
+            status: res.status,
+            message: `Error retrieving access token: ${
+              res.statusText || res.status
+            }`
+          }
         }
-
-        return res.json().then(data => ({ ok: true, status: res.status, data }))
+        return res.json().then(res => ({
+          ok: true,
+          status: 200,
+          accessToken: res.accessToken
+        }))
       })
       .then(res => {
         if (!res.ok) {
           consola.error(`${res.message} (${res.status})`)
-          return
+          return res
         }
-
-        config.set('accessToken', res.data.accessToken)
+        config.set('accessToken', res.accessToken)
         consola.success('Login success. Your session expires in 12h.')
       })
   }


### PR DESCRIPTION
This PR improves the help text message for `client-keys` command and renames option name from `clientId` to `keyId`.
Additionally, latest commit fixes error message logic when incorrect credentials are sent.

### Screenshots

<img width="725" alt="image" src="https://user-images.githubusercontent.com/6036099/172775382-fb6c210e-9943-470e-a1e9-269f1f5fece8.png">


### Process checklist

- [x] Manual tests passed.
- [ ] Automated tests added.
- [ ] Documentation updated.

### Related issue(s)

Closes #200

### Metrics

Actual effort: 3h
