### PR TITLE
Updates cluster remove route for admins

### DIFF
--- a/src/clusters/remove.js
+++ b/src/clusters/remove.js
@@ -53,7 +53,7 @@ async function removeCluster({ accessToken, force, ...flags }) {
   const env = config.get('env') || 'prod'
   const serviceUrl = config.get(`services.${env}.nodes.url`)
   const url = force
-    ? `${serviceUrl}/users/me/clusters/${clusterId}?force=${force}`
+    ? `${serviceUrl}/clusters/${clusterId}`
     : `${serviceUrl}/users/me/clusters/${clusterId}`
 
   return fetcher(url, 'DELETE', accessToken).then(res => {


### PR DESCRIPTION
This PR will update the route for cluster deletion on admin profile, the `--force` parameter is now used to call `/clusters/{clusterId}` and not passed to cloud-nodes anymore since it's not needed.

### Process checklist

- [x] Manual tests passed.
- [ ] Automated tests added.
- [ ] Documentation updated.

### Related issue(s)

Requires https://github.com/bloqpriv/cloud-nodes/pull/426

