### PR TITLE
Removes onDemandCapacity modifier on cluster creation/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ OPTIONS
   -F, --force                              force remove cluster from any user (admins only)
   -i, --clusterId=clusterId                cluster id
   -j, --json                               retrieves the data in JSON format
-  -o, --onDemandCapacity=onDemandCapacity  on-demand capacity
   -s, --serviceId=serviceId                service id
   -S, --sort=sort                          results sorting key
   -t, --authType=(jwt|basic|none)          [default: basic] auth type: jwt, basic or none

--- a/src/clusters/create.js
+++ b/src/clusters/create.js
@@ -24,20 +24,11 @@ const CLUSTER_MAX_CAPACITY = 10
  * @param {Object} params.serviceId Service ID
  * @param {Object} params.authType Authentication type
  * @param {Object} params.capacity Clusters total capacity
- * @param {Object} params.onDemandCapacity Clusters on-demand capacity
  * @param {Object} params.alias Clusters alias
  * @returns {Promise} The create cluster promise
  */
 async function createCluster(params) {
-  const {
-    accessToken,
-    authType,
-    capacity,
-    onDemandCapacity,
-    serviceId,
-    alias,
-    json
-  } = params
+  const { accessToken, authType, capacity, serviceId, alias, json } = params
 
   const isJson = typeof json !== 'undefined'
 
@@ -63,17 +54,9 @@ async function createCluster(params) {
     return
   }
 
-  if (onDemandCapacity < 1 || onDemandCapacity > capacity) {
-    formatErrorResponse(
-      isJson,
-      `Wrong cluster capacity. Capacity should be between ${CLUSTER_MIN_CAPACITY} and ${CLUSTER_MAX_CAPACITY}`
-    )
-    return
-  }
-
   !isJson && consola.info(`Creating a new cluster from service ${serviceId}.\n`)
 
-  const jsonBody = { serviceId, authType, capacity, onDemandCapacity, alias }
+  const jsonBody = { serviceId, authType, capacity, alias }
   const body = JSON.stringify(jsonBody)
   const env = config.get('env') || 'prod'
   const url = `${config.get(`services.${env}.nodes.url`)}/users/me/clusters`
@@ -96,7 +79,7 @@ async function createCluster(params) {
       version: res.data.serviceData.software,
       performance: res.data.serviceData.performance,
       domain: res.data.domain,
-      capacity: `${res.data.onDemandCapacity}:${res.data.capacity}`,
+      capacity: res.data.capacity,
       region: res.data.region,
       state: res.data.state,
       ...formatCredentials(res.data.auth)

--- a/src/clusters/info.js
+++ b/src/clusters/info.js
@@ -65,7 +65,7 @@ async function infoCluster({ accessToken, clusterId, json }) {
       version: res.data.serviceData.software,
       performance: res.data.serviceData.performance,
       domain: res.data.domain,
-      capacity: `${res.data.onDemandCapacity}:${res.data.capacity}`,
+      capacity: res.data.capacity,
       region: res.data.region,
       state: `${getState(res.data)}`,
       ...formatCredentials(res.data.auth)

--- a/src/clusters/update.js
+++ b/src/clusters/update.js
@@ -17,9 +17,7 @@ const getConfirmationMessage = flags =>
     ? 'You will cancel the current service update process of the cluster'
     : `You will update the cluster's ${
         flags.serviceId ? `service to ${flags.serviceId} and ` : ''
-      }capacity to ${flags.capacity} total and ${
-        flags.onDemandCapacity
-      } on-demand`
+      }capacity to ${flags.capacity} total`
 
 const getUrlAndMethod = ({ abort, clusterId }) => ({
   method: abort ? 'delete' : 'patch',
@@ -35,7 +33,6 @@ const getUrlAndMethod = ({ abort, clusterId }) => ({
  * @param {Object} params.accessToken Account access token
  * @param {Object} params.capacity Clusters total capacity
  * @param {Object} params.clusterId Cluster ID
- * @param {Object} params.onDemandCapacity Clusters on-demand capacity
  * @param {Object} params.serviceId Service ID
  * @param {Object} params.alias Clusters alias
  * @returns {Promise} The update cluster promise
@@ -62,15 +59,7 @@ async function updateCluster({ accessToken, json, ...flags }) {
     }
   ])
 
-  const {
-    yes,
-    clusterId,
-    capacity,
-    onDemandCapacity,
-    serviceId,
-    abort,
-    alias
-  } = {
+  const { yes, clusterId, capacity, serviceId, abort, alias } = {
     ...flags,
     ...prompt
   }
@@ -88,9 +77,7 @@ async function updateCluster({ accessToken, json, ...flags }) {
     url = `${serviceUrl}/users/me/clusters/${clusterId}/alias`
   } else {
     ;({ method, url } = getUrlAndMethod({ abort, clusterId }))
-    body = abort
-      ? null
-      : JSON.stringify({ capacity, onDemandCapacity, serviceId })
+    body = abort ? null : JSON.stringify({ capacity, serviceId })
   }
 
   return fetcher(url, method, accessToken, body).then(res => {

--- a/src/commands/clusters.js
+++ b/src/commands/clusters.js
@@ -52,10 +52,6 @@ ClusterCommand.flags = {
     description: 'capacity',
     default: 2
   }),
-  onDemandCapacity: flags.integer({
-    char: 'o',
-    description: 'on-demand capacity'
-  }),
   alias: flags.string({
     char: 'l',
     description: 'set or update cluster alias',

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -14,7 +14,7 @@ const services = config.get('services')
 
 const accountsUrl = new URL(
   services[env].accounts.statusEndpoint,
-  'https://accounts.bloqclouddev.com'
+  services[env].accounts.url
 )
 
 const nodesUrl = new URL(

--- a/src/nodes/logs.js
+++ b/src/nodes/logs.js
@@ -48,13 +48,11 @@ async function logsNode({ accessToken, nodeId, lines = 100 }) {
   // eslint-disable-next-line consistent-return
   return fetcher(url, 'GET', accessToken).then(res => {
     if (!res.ok) {
-      consola.error(
-        `Error retrieving node logs, requested resource not found: ${res.status}`
-      )
+      consola.error(`Error retrieving node logs: ${res.message}`)
       return
     }
 
-    console.log(res.data.data)
+    console.log(res.data)
   })
 }
 


### PR DESCRIPTION
This PR will remove the `-o` modifier for `clusters create` and `clusters update` commands. From now on, we will only use `-c` for capacity setting.

### Screenshots
<img width="976" alt="image" src="https://user-images.githubusercontent.com/6036099/185477332-52dfad4c-6045-43cc-af73-7196a289197e.png">


<img width="929" alt="image" src="https://user-images.githubusercontent.com/6036099/185476480-13613922-9a07-4b9e-ac29-d9affbe6d9e3.png">


### Process checklist

- [x] Manual tests passed.
- [ ] Automated tests added.
- [x] Documentation updated.

### Related issue(s)

<!-- Link the PR to the corresponding issues.
To link more than one issue, add new lines with the proper keyword.
Remove the lines that are not applicable. -->

Closes #219

### Metrics

Actual effort: 3.5h
