### PR TITLE
All nodes and cluster client versions

### DIFF
--- a/src/client-keys/create.js
+++ b/src/client-keys/create.js
@@ -4,7 +4,7 @@ const consola = require('consola')
 const inquirer = require('inquirer')
 const config = require('../config')
 const {
-  coppyToClipboard,
+  copyToClipboard,
   fetcher,
   formatOutput,
   formatErrorResponse
@@ -56,7 +56,7 @@ async function createClientKey({ user, accessToken, json }) {
       consola.warn(
         'You will NOT be able to see your client secret again. Remember to copy it and keep it safe.'
       )
-      coppyToClipboard(res.data.clientSecret, 'Client secret')
+      copyToClipboard(res.data.clientSecret, 'Client secret')
       consola.success(`Generated new client keys:`)
     }
 

--- a/src/clusters/create.js
+++ b/src/clusters/create.js
@@ -11,7 +11,7 @@ const {
 const jwtDecode = require('jwt-decode')
 
 const config = require('../config')
-const { coppyToClipboard } = require('../utils')
+const { copyToClipboard } = require('../utils')
 
 const CLUSTER_MIN_CAPACITY = 2
 const CLUSTER_MAX_CAPACITY = 10
@@ -89,7 +89,7 @@ async function createCluster(params) {
 
     if (!isJson) {
       consola.success(`Initialized new cluster from service ${serviceId}\n`)
-      coppyToClipboard(data.id, 'Cluster id')
+      copyToClipboard(data.id, 'Cluster id')
     }
   })
 }

--- a/src/clusters/list.js
+++ b/src/clusters/list.js
@@ -1,10 +1,17 @@
 'use strict'
 
-const consola = require('consola')
-const lodash = require('lodash')
-const { fetcher, formatErrorResponse, formatOutput } = require('../utils')
 require('console.table')
 
+const consola = require('consola')
+const lodash = require('lodash')
+
+const {
+  fetcher,
+  formatErrorResponse,
+  formatOutput,
+  getArchiveStatus,
+  getClientVersion
+} = require('../utils')
 const config = require('../config')
 
 /**
@@ -12,13 +19,14 @@ const config = require('../config')
  *
  * @param {Object} params object
  * @param {string} params.accessToken Account access token
- * @param {boolean} params.all Flag defining if it should show killed clusters
- * @param {string} params.allClusters List clusters from all users
- * @param {string} params.sort Key used to sort the output
+ * @param {boolean} [params.all] Flag defining if it should show killed clusters
+ * @param {string} [params.allClusters] List clusters from all users
+ * @param {string} [params.json] Format output as JSON
+ * @param {string} [params.sort] Key used to sort the output
 
  * @returns {Promise} The information cluster promise
  */
-async function listClusters({ accessToken, all, allClusters, sort, json }) {
+function listClusters({ accessToken, all, allClusters, sort, json }) {
   const isJson = typeof json !== 'undefined'
   !isJson && consola.info('Retrieving clusters...')
 
@@ -27,73 +35,87 @@ async function listClusters({ accessToken, all, allClusters, sort, json }) {
     allClusters ? '/clusters' : '/users/me/clusters'
   }`
 
-  return fetcher(url, 'GET', accessToken).then(res => {
-    if (!res.ok) {
-      formatErrorResponse(
-        isJson,
-        `Error retrieving all clusters: ${res.status}`
+  return fetcher(url, 'GET', accessToken)
+    .then(res => {
+      if (!res.ok) {
+        formatErrorResponse(
+          isJson,
+          `Error retrieving all clusters: ${res.status}`
+        )
+        return
+      }
+
+      const { data } = res
+      if (!data) {
+        return
+      }
+      if (!data.length) {
+        const user = `${config.get('user')}`
+        formatErrorResponse(isJson, `No clusters were found for user ${user}`)
+        return
+      }
+
+      // eslint-disable-next-line consistent-return
+      return Promise.all(
+        data.map(clusterRow =>
+          Promise.all([
+            getClientVersion(clusterRow).catch(() => 'error'),
+            getArchiveStatus(clusterRow)
+          ]).then(function ([clientVersion, archive]) {
+            const {
+              alias,
+              capacity,
+              chain,
+              createdAt,
+              healthCount = 0,
+              id,
+              name,
+              network,
+              serviceData = {},
+              state,
+              stoppedAt,
+              updatingService,
+              user
+            } = clusterRow
+
+            const cluster = {
+              id,
+              'alias/name': alias ? `${alias} (${name})` : name,
+              chain,
+              network,
+              'version': `${
+                clientVersion && clientVersion !== 'error'
+                  ? clientVersion
+                  : serviceData.software
+              }${archive !== null ? ` (${archive ? 'archive' : 'full'})` : ''}`,
+              'performance': serviceData.performance,
+              'cap': capacity,
+              'state':
+                state === 'started' && updatingService ? 'updating' : state,
+              'health': `${Math.round((healthCount / capacity) * 100)}%`,
+              createdAt
+            }
+
+            if (all) {
+              cluster.stoppedAt = stoppedAt
+            }
+            if (allClusters) {
+              cluster.user = user.email
+            }
+            return cluster
+          })
+        )
       )
-      return
-    }
-
-    let body = res.data
-    if (!body) {
-      return
-    }
-
-    if (!body.length) {
-      const user = `${config.get('user')}`
-      formatErrorResponse(isJson, `No clusters were found for user ${user}`)
-      return
-    }
-
-    body = body.map(function ({
-      alias,
-      capacity,
-      chain,
-      createdAt,
-      healthCount = 0,
-      id,
-      name,
-      network,
-      serviceData = {},
-      state,
-      stoppedAt,
-      updatingService,
-      user
-    }) {
-      const cluster = {
-        id,
-        chain,
-        network,
-        'name/alias': alias || name,
-        'state': state === 'started' && updatingService ? 'updating' : state,
-        'health': `${Math.round((healthCount / capacity) * 100)}%`,
-        createdAt,
-        'version': serviceData.software,
-        'performance': serviceData.performance
-      }
-
-      if (all) {
-        cluster.stoppedAt = stoppedAt
-      }
-      if (allClusters) {
-        cluster.user = user.email
-      }
-
-      return cluster
     })
+    .then(function (clusters) {
+      const body = all ? clusters : clusters.filter(n => n.state !== 'stopped')
 
-    if (!all) {
-      body = body.filter(n => n.state !== 'stopped')
-    }
-
-    !isJson && consola.success(`Got ${body.length} clusters:\n`)
-    formatOutput(
-      isJson,
-      lodash.sortBy(body, sort ? sort.split(',') : 'createdAt')
-    )
-  })
+      !isJson && consola.success(`Got ${body.length} clusters:\n`)
+      formatOutput(
+        isJson,
+        lodash.sortBy(body, sort ? sort.split(',') : 'createdAt')
+      )
+    })
 }
 
 module.exports = listClusters

--- a/src/commands/client-token.js
+++ b/src/commands/client-token.js
@@ -12,7 +12,7 @@ const inquirer = require('inquirer')
 const { Command, flags } = require('@oclif/command')
 
 const config = require('../config')
-const { coppyToClipboard } = require('../utils')
+const { copyToClipboard } = require('../utils')
 
 class ClientTokenCommand extends Command {
   async run() {
@@ -88,7 +88,7 @@ class ClientTokenCommand extends Command {
         config.set('refreshToken', data.refreshToken)
       }
 
-      coppyToClipboard(data.accessToken, 'Client access token')
+      copyToClipboard(data.accessToken, 'Client access token')
     })
   }
 }

--- a/src/commands/nodes.js
+++ b/src/commands/nodes.js
@@ -37,27 +37,33 @@ class NodesCommand extends Command {
 
 NodesCommand.description = 'Manage your Bloq nodes'
 NodesCommand.flags = {
-  serviceId: flags.string({ char: 's', description: 'service id' }),
-  authType: flags.enum({
-    char: 't',
-    description: 'auth type (jwt or basic)',
-    default: 'basic',
-    options: ['jwt', 'basic']
-  }),
   all: flags.boolean({
     char: 'a',
     description: 'list all nodes',
     default: false,
     required: false
   }),
+  allUsers: flags.boolean({
+    char: 'A',
+    description: 'list nodes from all user (admins only)',
+    default: false,
+    required: false
+  }),
+  authType: flags.enum({
+    char: 't',
+    description: 'auth type (jwt or basic)',
+    default: 'basic',
+    options: ['jwt', 'basic']
+  }),
   json: flags.boolean({ char: 'j', description: 'JSON output' }),
+  lines: flags.integer({ char: 'l', description: 'max lines to retrieve' }),
   nodeId: flags.string({ char: 'i', description: 'node id' }),
+  serviceId: flags.string({ char: 's', description: 'service id' }),
   yes: flags.boolean({
     char: 'y',
     description: 'answer "yes" to prompts',
     default: false
-  }),
-  lines: flags.integer({ char: 'l', description: 'max lines to retrieve' })
+  })
 }
 
 NodesCommand.args = [

--- a/src/nodes/create.js
+++ b/src/nodes/create.js
@@ -11,7 +11,7 @@ const {
 const jwtDecode = require('jwt-decode')
 
 const config = require('../config')
-const { coppyToClipboard } = require('../utils')
+const { copyToClipboard } = require('../utils')
 
 /**
  * Creates a node from a service ID (Valid for admin users)
@@ -86,7 +86,7 @@ async function createNode({ accessToken, serviceId, authType, json }) {
 
     if (!isJson) {
       consola.success(`Initialized new node from service ${serviceId}\n`)
-      coppyToClipboard(res.data.id, 'Node id')
+      copyToClipboard(res.data.id, 'Node id')
     }
   })
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ const ora = require('ora')
  * @param {string} value What to copy to the clipboard.
  * @param {string} name The name of what is being copied.
  */
-const coppyToClipboard = (value, name) =>
+const copyToClipboard = (value, name) =>
   clipboardy
     .write(value)
     .then(() => consola.info(`${name} was copied to the clipboard.`))
@@ -115,7 +115,7 @@ const formatOutput = (isJson, dataObj) => {
 }
 
 module.exports = {
-  coppyToClipboard,
+  copyToClipboard,
   fetcher,
   formatCredentials,
   formatOutput,


### PR DESCRIPTION
<!-- Explain the changes included in this PR and why are relevant or what problem does it solve. -->

This PR updates the `nodes list` command so admins can easily retrieve all user's nodes with the `-A` option. It also updates the `clusters list` command to show the exact software client version running.

```console
$ bcl clusters list -A
ℹ Retrieving clusters...                                                                                                                                                                                                                                                                              15:34:35
✔ Got 2 clusters:                                                                                                                                                                                                                                                                                     15:34:39

id                                            alias/name                                        chain     network  version                 performance  cap  state    health  createdAt                 user            
--------------------------------------------  ------------------------------------------------  --------  -------  ----------------------  -----------  ---  -------  ------  ------------------------  ----------------
cluster-[redacte...........................]  [redacted......................................]  eth       mainnet  Geth v1.12.0 (full)     standard     2    started  100%    [redacted..............]  [redacted......]
cluster-[redacte...........................]  [redacted......................................]  eth       goerli   Geth v1.12.0 (archive)  standard     2    started  100%    [redacted..............]  [redacted......]

$ bcl nodes list -A 
ℹ Retrieving all nodes                                                                                                                                                                                                                                                                                15:36:28

✔ Got 2 nodes:                                                                                                                                                                                                                                                                                        15:36:30

id                                         ip              chain      network  version          performance  state    createdAt                 user                                     
-----------------------------------------  --------------  ---------  -------  ---------------  -----------  -------  ------------------------  -----------------------------------------
node-[redacted..........................]  [redacted....]  avalanche  fuji     avalanchego-1.7  standard     started  [redacted..............]  user-[redacted..........................]
node-[redacted..........................]  [redacted....]  avalanche  fuji     avalanchego-1.7  standard     started  [redacted..............]  user-[redacted..........................]
```

### Process checklist

- [x] Manual tests passed.
- [x] Documentation updated.

### Related issue(s)

<!-- Link the PR to the corresponding issues.
To link more than one issue, add new lines with the proper keyword.
Remove the lines that are not applicable. -->

Related to #222 and #224

### Metrics

<!-- Add the actual effort spent working in this PR.
Use hours or days as appropriate.
Consider 0.5h as the lower limit. -->

Actual effort: 1.5h
